### PR TITLE
Fix decimal isnumeric

### DIFF
--- a/pandas/core/strings/object_array.py
+++ b/pandas/core/strings/object_array.py
@@ -468,7 +468,13 @@ class ObjectStringArrayMixin(BaseStringArrayMethods):
         return self._str_map(str.islower, dtype="bool")
 
     def _str_isnumeric(self):
-        return self._str_map(str.isnumeric, dtype="bool")
+        def is_numeric(value):
+            try:
+                float(value)  # Try converting to float (supports negative and decimals)
+                return True
+            except ValueError:
+                return False
+        return self._str_map(is_numeric, dtype="bool")
 
     def _str_isspace(self):
         return self._str_map(str.isspace, dtype="bool")

--- a/pandas/core/strings/object_array.py
+++ b/pandas/core/strings/object_array.py
@@ -469,11 +469,15 @@ class ObjectStringArrayMixin(BaseStringArrayMethods):
 
     def _str_isnumeric(self):
         def is_numeric(value):
-            try:
-                float(value)  # Try converting to float (supports negative and decimals)
+            if value.isnumeric():
                 return True
-            except ValueError:
-                return False
+            else:
+                try:
+                    float(value)  # Try converting to float (supports negative and decimals)
+                    return True
+                except ValueError:
+                    return False
+
         return self._str_map(is_numeric, dtype="bool")
 
     def _str_isspace(self):

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -240,8 +240,8 @@ def test_ismethods(method, expected, any_string_dtype):
 @pytest.mark.parametrize(
     "method, expected",
     [
-        ("isnumeric", [False, True, True, False, True, True, False]),
-        ("isdecimal", [False, True, False, False, False, True, False]),
+        ("isnumeric", [False, True, True, False, True, True, False, True, True]),
+        ("isdecimal", [False, True, False, False, False, True, False, True, True]),
     ],
 )
 def test_isnumeric_unicode(method, expected, any_string_dtype):
@@ -250,7 +250,7 @@ def test_isnumeric_unicode(method, expected, any_string_dtype):
     # 0x1378: ፸ ETHIOPIC NUMBER SEVENTY
     # 0xFF13: ３ Em 3  # noqa: RUF003
     ser = Series(
-        ["A", "3", "¼", "★", "፸", "３", "four"],  # noqa: RUF001
+        ["A", "3", "¼", "★", "፸", "３", "four", "1.2", "0.0"],  # noqa: RUF001
         dtype=any_string_dtype,
     )
     expected_dtype = (


### PR DESCRIPTION
- [x] closes #60750 
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

`isnumeric` now works to include decimal strings to be evaluated as true.
